### PR TITLE
fix: allow using spaced numbers

### DIFF
--- a/src/VueExcelEditor.vue
+++ b/src/VueExcelEditor.vue
@@ -2590,7 +2590,7 @@ export default defineComponent({
     },
     setFieldError (error, row, field) {
       const id = `id-${row.$id}-${field.name}`
-      const selector = this.systable.querySelector('td#'+id)
+      const selector = this.systable.querySelector(`td[id="${id}"]`)
       if (error) {
         this.errmsg[id] = error
         this.$emit('validate-error', error, row, field)
@@ -2605,7 +2605,7 @@ export default defineComponent({
     },
     setRowError (error, row) {
       const rid = `rid-${row.$id}`
-      const selector = this.systable.querySelector('td#'+rid)
+      const selector = this.systable.querySelector(`td[id="${rid}"]`)
       if (error) {
         this.rowerr[rid] = error
         this.$emit('validate-error', error, row)


### PR DESCRIPTION
querySelector will fail on id's like:` id-123123-000001-Column 1`