### PR TITLE
Switch xlsx package to fix vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@vuepic/vue-datepicker": "^3.3.0",
     "vuedraggable": "^4.1.0",
-    "xlsx": "^0.18.5"
+    "@e965/xlsx": "^0.20.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since xlsx package isn't published on npm registry anymore, I suggest to replace it by [@e265/xlsx](https://www.npmjs.com/package/@e965/xlsx?activeTab=readme) to fix these vulnerabilities : 
- Prototype Pollution in sheetJS - https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
- SheetJS Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-5pgg-2g8v-p4x9

As said on the readme of this package, "It automatically takes a fresh version of SheetJS from their git repository, and publishes to npm if the version is different. The whole process is automated and works through Github Actions."